### PR TITLE
Add tags to admin views

### DIFF
--- a/app/Http/Controllers/SubscriberController.php
+++ b/app/Http/Controllers/SubscriberController.php
@@ -15,7 +15,7 @@ class SubscriberController extends Controller
     public function index()
     {
         return view('admin.subscribers.index', [
-            'subscribers' => Subscriber::latest()->paginate(25),
+            'subscribers' => Subscriber::latest()->withCount('tags')->paginate(25),
         ]);
     }
 

--- a/app/Http/Controllers/TagController.php
+++ b/app/Http/Controllers/TagController.php
@@ -4,15 +4,14 @@ namespace App\Http\Controllers;
 
 use App\Tag;
 use Illuminate\Http\Request;
-use Validator;
 
 class TagController extends Controller
 {
     public function index()
     {
         return view('admin.tags.index', [
-            'locationTags' => Tag::locations()->get(),
-            'topicTags' => Tag::topics()->get(),
+            'locationTags' => Tag::locations()->withCount('subscribers')->get(),
+            'topicTags' => Tag::topics()->withCount('subscribers')->get(),
         ]);
     }
 
@@ -41,7 +40,6 @@ class TagController extends Controller
         return redirect('/admin/tags')
             ->with('status', 'Tag created.');
     }
-
 
     public function edit(Tag $tag)
     {
@@ -72,7 +70,7 @@ class TagController extends Controller
     public function destroy(Tag $tag)
     {
         $tag->delete();
+
         return redirect('/admin/tags')->with('status', 'Tag deleted.');
     }
-
 }

--- a/app/Subscriber.php
+++ b/app/Subscriber.php
@@ -45,7 +45,7 @@ class Subscriber extends Authenticatable
 
     public function tags()
     {
-        return $this->belongsToMany('App\Tag');
+        return $this->belongsToMany(Tag::class);
     }
 
     public function locationTags()
@@ -56,15 +56,6 @@ class Subscriber extends Authenticatable
     public function topicTags()
     {
         return $this->tags()->where('category', 'topic');
-    }
-
-    public function tagIds()
-    {
-        $data = collect($this->tags()->select('id')->get());
-
-        return $data->map(function ($tag) {
-            return $tag->id;
-        });
     }
 
     public function subscribe()

--- a/app/Tag.php
+++ b/app/Tag.php
@@ -10,6 +10,11 @@ class Tag extends Model
         'name', 'category', 'subscriber_default', 'message_default',
     ];
 
+    public function subscribers()
+    {
+        return $this->belongsToMany(Subscriber::class);
+    }
+
     public static function categoryOptions()
     {
         return [
@@ -41,8 +46,11 @@ class Tag extends Model
     public static function validateRequiredTags($ids)
     {
         // Validates at least one tag is selected per category.
-        if (!$ids) return false;
+        if (! $ids) {
+            return false;
+        }
         $cats = self::select('category')->distinct()->whereIn('id', $ids)->get();
+
         return $cats->count() == count(self::categoryOptions());
     }
 }

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -8,5 +8,6 @@ use Faker\Generator as Faker;
 $factory->define(Tag::class, function (Faker $faker) {
     return [
         'name' => $faker->name,
+        'category' => $faker->randomElement(array_keys(Tag::categoryOptions())),
     ];
 });

--- a/resources/js/tag-manager.js
+++ b/resources/js/tag-manager.js
@@ -1,3 +1,6 @@
+let axios = require('axios');
+axios.defaults.headers.common['X-Requested-With'] = 'XMLHttpRequest';
+
 export default options => {
     return {
         updateEndpoint: '',

--- a/resources/views/admin/subscribers/form.blade.php
+++ b/resources/views/admin/subscribers/form.blade.php
@@ -20,6 +20,28 @@
                 :checked="old('subscribed', $subscriber->subscribed)"
             />
         </div>
+        <h2 class="text-xl font-bold mt-6">@lang('Notification Preferences')</h2>
+        <div class="mt-4 grid grid-cols-2 gap-4">
+            @php $selected = collect(old('tags', $subscriber->tags->pluck('id'))); @endphp
+            <x-fieldset :label="__('Locations')">
+                <ul>
+                    @foreach($locationTags as $tag)
+                        <li class="text-sm">
+                            <x-checkbox :label="$tag->name" name="tags[]" :value="$tag->id" :checked="$selected->contains($tag->id)" />
+                        </li>
+                    @endforeach
+                </ul>
+            </x-fieldset>
+            <x-fieldset :label="__('Topics')">
+                <ul>
+                    @foreach($topicTags as $tag)
+                        <li class="text-sm">
+                            <x-checkbox :label="$tag->name" name="tags[]" :value="$tag->id" :checked="$selected->contains($tag->id)" />
+                        </li>
+                    @endforeach
+                </ul>
+            </x-fieldset>
+        </div>
     </div>
     <div class="bg-gray-100 border-t border-gray-200 flex justify-{{ $subscriber->exists ? 'between' : 'end' }} items-center px-4 py-4 sm:px-6">
         @if ($subscriber->exists)

--- a/resources/views/admin/subscribers/index.blade.php
+++ b/resources/views/admin/subscribers/index.blade.php
@@ -17,6 +17,7 @@
                 <th class="px-4 py-4 sm:px-6">Subscriber Number</th>
                 <th class="px-4 py-4 sm:px-6">Subscribed</th>
                 <th class="px-4 py-4 sm:px-6">Locale</th>
+                <th class="px-4 py-4 sm:px-6">Tags</th>
                 <th class="px-4 py-4 sm:px-6">Created</th>
                 <th class="px-4 py-4 sm:px-6">Updated</th>
             </tr>
@@ -54,6 +55,9 @@
                         >
                             {{ $subscriber->locale }}
                         </a>
+                    </td>
+                    <td class="border-t px-4 sm:px-6">
+                        {{ $subscriber->tags_count }}
                     </td>
                     <td class="border-t">
                         <a

--- a/resources/views/admin/tags/index.blade.php
+++ b/resources/views/admin/tags/index.blade.php
@@ -20,6 +20,7 @@
                 <th class="px-4 py-4 sm:px-6">Name</th>
                 <th class="px-4 py-4 sm:px-6">Subscriber Default</th>
                 <th class="px-4 py-4 sm:px-6">Message Default</th>
+                <th class="px-4 py-4 sm:px-6">Subscribers</th>
             </tr>
         </thead>
         <tbody>
@@ -47,6 +48,9 @@
                         @else
                             <div class="w-8 text-center">—</div>
                         @endif
+                    </td>
+                    <td class="border-t px-4 py-4 sm:px-6">
+                        {{ $tag->subscribers_count }}
                     </td>
                 </tr>
             @endforeach

--- a/resources/views/subscriber/home.blade.php
+++ b/resources/views/subscriber/home.blade.php
@@ -75,7 +75,7 @@
                         <div
                             x-data="tagManager({
                                 updateEndpoint: '{{ route('subscriber.updateTags') }}',
-                                activeTags: {{ json_encode($subscriber->tagIds()) }}
+                                activeTags: {{ json_encode($subscriber->tags->pluck('id')) }}
                             })"
                             class="mt-4 grid grid-cols-2 gap-4"
                         >

--- a/tests/Feature/SubscriberTest.php
+++ b/tests/Feature/SubscriberTest.php
@@ -2,10 +2,11 @@
 
 namespace Tests\Feature;
 
-use Tests\TestCase;
-use Illuminate\Foundation\Testing\RefreshDatabase;
 use App\Message;
 use App\Subscriber;
+use App\Tag;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
 
 class SubscriberTest extends TestCase
 {
@@ -45,7 +46,7 @@ class SubscriberTest extends TestCase
             ->assertRedirect(route('subscribers.admin.index'));
 
         $this->assertDatabaseHas('subscribers', [
-            'number' => $subscriber->number
+            'number' => $subscriber->number,
         ]);
     }
 
@@ -59,13 +60,17 @@ class SubscriberTest extends TestCase
 
     public function testAdminCanUpdateSubscriber()
     {
+        $tags = factory(Tag::class, 2)->create();
         $subscriber = factory(Subscriber::class)->create(['subscribed' => true]);
         $this->signIn(['admin' => 1])
             ->withoutExceptionHandling()
-            ->put(route('subscribers.admin.update', $subscriber), [])
+            ->put(route('subscribers.admin.update', $subscriber), [
+                'tags' => $tags->pluck('id'),
+            ])
             ->assertRedirect(route('subscribers.admin.index'));
 
         $this->assertDatabaseHas('subscribers', ['subscribed' => false]);
+        $this->assertEquals($subscriber->fresh()->tags->pluck('id'), $tags->pluck('id'));
     }
 
     public function testSubscribeFromSite()


### PR DESCRIPTION
These updates allow admins to view and edit subscriber tags. If admins shouldn't have the ability to edit though I can make that read-only. Resolves #99 